### PR TITLE
게시글 페이지네이션 구현

### DIFF
--- a/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/controller/ArticleController.java
+++ b/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/controller/ArticleController.java
@@ -56,6 +56,7 @@ public class ArticleController {
         ArticleWithCommentsResponse article = ArticleWithCommentsResponse.from(articleService.getArticle(articleId));
         map.addAttribute("article", article);
         map.addAttribute("articleComments", article.articleCommentsResponse());
+        map.addAttribute("totalCount", articleService.getArticleCount());
         return "articles/detail";
     }
 }

--- a/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/service/ArticleService.java
+++ b/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/service/ArticleService.java
@@ -70,4 +70,8 @@ public class ArticleService {
         articleRepository.deleteById(articleId);
     }
 
+    public long getArticleCount(){
+        return articleRepository.count();
+    }
+
 }

--- a/fastcampus-project-board/src/main/resources/templates/articles/detail.html
+++ b/fastcampus-project-board/src/main/resources/templates/articles/detail.html
@@ -31,7 +31,7 @@
             </section>
 
             <article id="article-content" class="col-md-7 col-lg-8">
-                <p>본문<br><br></p>
+                <pre>본문</pre>
             </article>
         </div>
 
@@ -74,7 +74,7 @@
         </div>
 
         <div class="row g-5">
-            <nav aria-label="Page navigation example">
+            <nav id="pagination" aria-label="Page navigation">
                 <ul class="pagination">
                     <li class="page-item">
                         <a class="page-link" href="#" aria-label="Previous">

--- a/fastcampus-project-board/src/main/resources/templates/articles/detail.th.xml
+++ b/fastcampus-project-board/src/main/resources/templates/articles/detail.th.xml
@@ -1,26 +1,35 @@
 <?xml version="1.0"?>
 <thlogic>
-    <attr sel="#header" th:replace="header :: header"/>
-    <attr sel="#footer" th:replace="footer :: footer"/>
+    <attr sel="#header" th:replace="header :: header" />
+    <attr sel="#footer" th:replace="footer :: footer" />
 
     <attr sel="#article-main" th:object="${article}">
-        <attr sel="#article-header/h1" th:text="*{title}"/>
-        <attr sel="#nickname" th:text="*{nickname}"/>
-        <attr sel="#email" th:text="*{email}"/>
-        <attr sel="#created-at" th:datetime="*{createdAt}" th:text="*{#temporals.format(createdAt, 'yyyy-MM-dd HH:mm:ss')}"/>
-        <attr sel="#hashtag" th:text="*{hashtag}"/>
-        <attr sel="#article-content/p" th:text="*{content}"/>
-    </attr>
+        <attr sel="#article-header/h1" th:text="*{title}" />
+        <attr sel="#nickname" th:text="*{nickname}" />
+        <attr sel="#email" th:text="*{email}" />
+        <attr sel="#created-at" th:datetime="*{createdAt}" th:text="*{#temporals.format(createdAt, 'yyyy-MM-dd HH:mm:ss')}" />
+        <attr sel="#hashtag" th:text="*{hashtag}" />
+        <attr sel="#article-content/pre" th:text="*{content}" />
 
-    <attr sel="#article-comments" th:remove="all-but-first">
-        <attr sel="li[0]" th:each="articleComment : ${articleComments}">
-            <attr sel="div/strong" th:text="${articleComment.nickname}"/>
-            <attr sel="div/small/time" th:datetime="${articleComment.createdAt}" th:text="${#temporals.format(articleComment.createdAt, 'yyyy-MM-dd HH:mm:ss')}"/>
-            <attr sel="div/p" th:text="${articleComment.content}"/>
-
-
+        <attr sel="#article-comments" th:remove="all-but-first">
+            <attr sel="li[0]" th:each="articleComment : ${articleComments}">
+                <attr sel="div/strong" th:text="${articleComment.nickname}" />
+                <attr sel="div/small/time" th:datetime="${articleComment.createdAt}" th:text="${#temporals.format(articleComment.createdAt, 'yyyy-MM-dd HH:mm:ss')}" />
+                <attr sel="div/p" th:text="${articleComment.content}" />
+            </attr>
         </attr>
 
+        <attr sel="#pagination">
+            <attr sel="ul">
+                <attr sel="li[0]/a"
+                      th:href="*{id} - 1 <= 0 ? '#' : |/articles/*{id - 1}|"
+                      th:class="'page-link' + (*{id} - 1 <= 0 ? ' disabled' : '')"
+                />
+                <attr sel="li[1]/a"
+                      th:href="*{id} + 1 > ${totalCount} ? '#' : |/articles/*{id + 1}|"
+                      th:class="'page-link' + (*{id} + 1 > ${totalCount} ? ' disabled' : '')"
+                />
+            </attr>
+        </attr>
     </attr>
-
 </thlogic>


### PR DESCRIPTION
`이전 글`, `다음 글`만 구현하므로 게시판에 비해 단순하지만
첫 글, 마지막 글은 버튼 비활성화 및 가짜 링크 처리해야 해서
타임리프 문법이 복잡해짐

마지막 글을 판단하기 위해 총 글 개수가 필요해졌고
이를 위해 count 쿼리 사용, 서비스 로직 추가

This closes #22 