### PR TITLE
헤더에 해시태그 메뉴 추가하기

### DIFF
--- a/fastcampus-project-board/src/main/resources/templates/header.html
+++ b/fastcampus-project-board/src/main/resources/templates/header.html
@@ -10,7 +10,8 @@
     <div class="container">
         <div class="d-flex flex-wrap align-items-center justify-content-center justify-content-lg-start">
             <ul class="nav col-12 col-lg-auto me-lg-auto mb-2 justify-content-center mb-md-0">
-                <li><a href="/" class="nav-link px-2 text-secondary">Home</a></li>
+                <li><a id="home" href="#" class="nav-link px-2 text-secondary">Home</a></li>
+                <li><a id="hashtag" href="#" class="nav-link px-2 text-secondary">Hashtags</a></li>
             </ul>
 
             <div class="text-end">

--- a/fastcampus-project-board/src/main/resources/templates/header.th.xml
+++ b/fastcampus-project-board/src/main/resources/templates/header.th.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<thlogic>
+    <attr sel="#home" th:href="@{/}" />
+    <attr sel="#hashtag" th:href="@{/articles/search-hashtag}" />
+</thlogic>


### PR DESCRIPTION
#33에서 검색 페이지는 구현 했지만 이동하기 번거로워 헤더에 메뉴를 추가함.